### PR TITLE
Add Field Neutraliser

### DIFF
--- a/outfitting.csv
+++ b/outfitting.csv
@@ -890,3 +890,4 @@ id,symbol,category,name,mount,guidance,ship,class,rating,entitlement
 128793116,Int_DroneControl_UnkVesselResearch,internal,Research Limpet Controller,,,,1,E,horizons
 128785626,Hpt_FlakMortar_Fixed_Medium,hardpoint,Remote Release Flak Launcher,Fixed,,,2,B,horizons
 128793058,Hpt_FlakMortar_Turret_Medium,hardpoint,Remote Release Flak Launcher,Turreted,,,2,B,horizons
+128771884,Hpt_AntiUnknownShutdown_Tiny,utility,Field Neutraliser,,,,0,F,horizons


### PR DESCRIPTION
The new module from the 4th AEGIS CG.  Full JSON when installed:

      "TinyHardpoint1": {
        "module": {
          "free": false,
          "health": 1000000,
          "id": 128771884,
          "locDescription": "Counters current xeno shutdown technology when used within proximity.",
          "locName": "Field Neutraliser",
          "name": "Hpt_AntiUnknownShutdown_Tiny",
          "on": true,
          "priority": 2,
          "value": 52212
        }

JSON of market entry:
      "128771884": {
        "category": "utility",
        "cost": 52212,
        "id": 128771884,
        "name": "Hpt_AntiUnknownShutdown_Tiny",
        "sku": "ELITE_HORIZONS_V_PLANETARY_LANDINGS"
      },