### PR TITLE
Guardian/Tech Broker Module update for 3.1

### DIFF
--- a/outfitting.csv
+++ b/outfitting.csv
@@ -900,15 +900,25 @@ id,symbol,category,name,mount,guidance,ship,class,rating,entitlement
 128793060,Hpt_ATMultiCannon_Turret_Large,hardpoint,AX Multi-Cannon,Turreted,,,3,E,horizons
 128793115,Hpt_XenoScanner_Basic_Tiny,utility,Xeno Scanner,,,,0,E,horizons
 128793116,Int_DroneControl_UnkVesselResearch,internal,Research Limpet Controller,,,,1,E,horizons
+128793117,Int_MetaAlloyHullReinforcement_Size1_Class1,internal,Meta Alloy Hull Reinforcement,,,1,E,horizons
+128793118,Int_MetaAlloyHullReinforcement_Size1_Class2,internal,Meta Alloy Hull Reinforcement,,,1,D,horizons
+128793119,Int_MetaAlloyHullReinforcement_Size2_Class1,internal,Meta Alloy Hull Reinforcement,,,2,E,horizons
+128793120,Int_MetaAlloyHullReinforcement_Size2_Class2,internal,Meta Alloy Hull Reinforcement,,,2,D,horizons
+128793121,Int_MetaAlloyHullReinforcement_Size3_Class1,internal,Meta Alloy Hull Reinforcement,,,3,E,horizons
+128793122,Int_MetaAlloyHullReinforcement_Size3_Class2,internal,Meta Alloy Hull Reinforcement,,,3,D,horizons
+128793123,Int_MetaAlloyHullReinforcement_Size4_Class1,internal,Meta Alloy Hull Reinforcement,,,4,E,horizons
+128793124,Int_MetaAlloyHullReinforcement_Size4_Class2,internal,Meta Alloy Hull Reinforcement,,,4,D,horizons
+128793125,Int_MetaAlloyHullReinforcement_Size5_Class1,internal,Meta Alloy Hull Reinforcement,,,5,E,horizons
+128793126,Int_MetaAlloyHullReinforcement_Size5_Class2,internal,Meta Alloy Hull Reinforcement,,,5,D,horizons
 128793941,Int_DroneControl_Decontamination_Size1_Class1,internal,Decontamination Limpet Controller,,,,1,E,horizons
 128793942,Int_DroneControl_Decontamination_Size3_Class1,internal,Decontamination Limpet Controller,,,,3,E,horizons
 128793943,Int_DroneControl_Decontamination_Size5_Class1,internal,Decontamination Limpet Controller,,,,5,E,horizons
 128793944,Int_DroneControl_Decontamination_Size7_Class1,internal,Decontamination Limpet Controller,,,,7,E,horizons
-128816569,Krait_Mkii_Armour_Grade1,standard,Lightweight Alloy,,,Krait MkII,1,I,horizons
-128816570,Krait_Mkii_Armour_Grade2,standard,Reinforced Alloy,,,Krait MkII,1,I,horizons
-128816571,Krait_Mkii_Armour_Grade3,standard,Military Grade Composite,,,Krait MkII,1,I,horizons
-128816572,Krait_Mkii_Armour_Mirrored,standard,Mirrored Surface Composite,,,Krait MkII,1,I,horizons
-128816573,Krait_Mkii_Armour_Reactive,standard,Reactive Surface Composite,,,Krait MkII,1,I,horizons
+128816569,Krait_MkII_Armour_Grade1,standard,Lightweight Alloy,,,Krait MkII,1,I,horizons
+128816570,Krait_MkII_Armour_Grade2,standard,Reinforced Alloy,,,Krait MkII,1,I,horizons
+128816571,Krait_MkII_Armour_Grade3,standard,Military Grade Composite,,,Krait MkII,1,I,horizons
+128816572,Krait_MkII_Armour_Mirrored,standard,Mirrored Surface Composite,,,Krait MkII,1,I,horizons
+128816573,Krait_MkII_Armour_Reactive,standard,Reactive Surface Composite,,,Krait MkII,1,I,horizons
 128816576,TypeX_Armour_Grade1,standard,Lightweight Alloy,,,Alliance Chieftain,1,I,horizons
 128816577,TypeX_Armour_Grade2,standard,Reinforced Alloy,,,Alliance Chieftain,1,I,horizons
 128816578,TypeX_Armour_Grade3,standard,Military Grade Composite,,,Alliance Chieftain,1,I,horizons
@@ -919,26 +929,75 @@ id,symbol,category,name,mount,guidance,ship,class,rating,entitlement
 128816592,TypeX_3_Armour_Grade3,standard,Military Grade Composite,,,Alliance Challenger,1,I,horizons
 128816593,TypeX_3_Armour_Mirrored,standard,Mirrored Surface Composite,,,Alliance Challenger,1,I,horizons
 128816594,TypeX_3_Armour_Reactive,standard,Reactive Surface Composite,,,Alliance Challenger,1,I,horizons
-128833687,Hpt_Guardian_GaussCannon_Fixed_Medium,Guardian Gauss Cannon,,Fixed,,,2,B,horizons
-128833944,Int_CorrosionProofCargoRack_Size4_Class1,Corrosion Resistant Cargo Rack,,,,,4,E,horizons
-128833988,Int_GuardianPowerplant_Size2,Guardian Power Plant,,,,,2,A,horizons
-128833989,Int_GuardianPowerplant_Size3,Guardian Power Plant,,,,,3,A,horizons
-128833990,Int_GuardianPowerplant_Size4,Guardian Power Plant,,,,,4,A,horizons
-128833991,Int_GuardianPowerplant_Size5,Guardian Power Plant,,,,,5,A,horizons
-128833992,Int_GuardianPowerplant_Size6,Guardian Power Plant,,,,,6,A,horizons
-128833993,Int_GuardianPowerplant_Size7,Guardian Power Plant,,,,,7,A,horizons
-128833994,Int_GuardianPowerplant_Size8,Guardian Power Plant,,,,,8,A,horizons
-128833998,Hpt_Guardian_PlasmaLauncher_Fixed_Medium,Guardian Plasma Charger,,Fixed,,,2,B,horizons
-128833999,Hpt_Guardian_PlasmaLauncher_Turret_Medium,Guardian Plasma Charger,,Turreted,,,2,E,horizons
-128834000,Hpt_Guardian_ShardCannon_Fixed_Medium,Shard Cannon,,Fixed,,,2,A,horizons
-128834001,Hpt_Guardian_ShardCannon_Turret_Medium,Shard Cannon,,Turreted,,,2,A,horizons
-128834778,Hpt_Guardian_ShardCannon_Fixed_Large,Shard Cannon,,Fixed,,,3,,horizons
-128834779,Hpt_Guardian_ShardCannon_Turret_Large,Shard Cannon,,Turreted,,,3,,horizons
-128834780,Hpt_PlasmaShockCannon_Fixed_Large,Shock Cannon,,Fixed,,,3,,horizons
-128834781,Hpt_PlasmaShockCannon_Gimbal_Large,Shock Cannon,,Gimballed,,,3,,horizons
-128834782,Hpt_PlasmaShockCannon_Turret_Large,Shock Cannon,,Turreted,,,3,,horizons
-128834783,Hpt_Guardian_PlasmaLauncher_Fixed_Large,,Fixed,,,3,,horizons
-128834784,Hpt_Guardian_PlasmaLauncher_Turret_Large,,Turreted,,,3,,horizons
+128833687,Hpt_Guardian_GaussCannon_Fixed_Medium,hardpoint,Guardian Gauss Cannon,Fixed,,,2,B,horizons
+128833944,Int_CorrosionProofCargoRack_Size4_Class1,internal,Corrosion Resistant Cargo Rack,,,,4,E,horizons
+128833945,Int_GuardianHullReinforcement_Size1_Class1,internal,Guardian Hull Reinforcement,,,,1,E,horizons
+128833946,Int_GuardianHullReinforcement_Size1_Class2,internal,Guardian Hull Reinforcement,,,,1,D,horizons
+128833947,Int_GuardianHullReinforcement_Size2_Class1,internal,Guardian Hull Reinforcement,,,,2,E,horizons
+128833948,Int_GuardianHullReinforcement_Size2_Class2,internal,Guardian Hull Reinforcement,,,,2,D,horizons
+128833949,Int_GuardianHullReinforcement_Size3_Class1,internal,Guardian Hull Reinforcement,,,,3,E,horizons
+128833950,Int_GuardianHullReinforcement_Size3_Class2,internal,Guardian Hull Reinforcement,,,,3,D,horizons
+128833951,Int_GuardianHullReinforcement_Size4_Class1,internal,Guardian Hull Reinforcement,,,,4,E,horizons
+128833952,Int_GuardianHullReinforcement_Size4_Class2,internal,Guardian Hull Reinforcement,,,,4,D,horizons
+128833953,Int_GuardianHullReinforcement_Size5_Class1,internal,Guardian Hull Reinforcement,,,,5,E,horizons
+128833954,Int_GuardianHullReinforcement_Size5_Class2,internal,Guardian Hull Reinforcement,,,,5,D,horizons
+128833955,Int_GuardianModuleReinforcement_Size1_Class1,internal,Guardian Module Reinforcement,,,,1,E,horizons
+128833956,Int_GuardianModuleReinforcement_Size1_Class2,internal,Guardian Module Reinforcement,,,,1,D,horizons
+128833957,Int_GuardianModuleReinforcement_Size2_Class1,internal,Guardian Module Reinforcement,,,,2,E,horizons
+128833958,Int_GuardianModuleReinforcement_Size2_Class2,internal,Guardian Module Reinforcement,,,,2,D,horizons
+128833959,Int_GuardianModuleReinforcement_Size3_Class1,internal,Guardian Module Reinforcement,,,,3,E,horizons
+128833960,Int_GuardianModuleReinforcement_Size3_Class2,internal,Guardian Module Reinforcement,,,,3,D,horizons
+128833961,Int_GuardianModuleReinforcement_Size4_Class1,internal,Guardian Module Reinforcement,,,,4,E,horizons
+128833962,Int_GuardianModuleReinforcement_Size4_Class2,internal,Guardian Module Reinforcement,,,,4,D,horizons
+128833963,Int_GuardianModuleReinforcement_Size5_Class1,internal,Guardian Module Reinforcement,,,,5,E,horizons
+128833964,Int_GuardianModuleReinforcement_Size5_Class2,internal,Guardian Module Reinforcement,,,,5,D,horizons
+128833965,Int_GuardianShieldReinforcement_Size1_Class1,internal,Guardian Shield Reinforcement,,,,1,E,horizons
+128833966,Int_GuardianShieldReinforcement_Size1_Class2,internal,Guardian Shield Reinforcement,,,,1,D,horizons
+128833967,Int_GuardianShieldReinforcement_Size2_Class1,internal,Guardian Shield Reinforcement,,,,2,E,horizons
+128833968,Int_GuardianShieldReinforcement_Size2_Class2,internal,Guardian Shield Reinforcement,,,,2,D,horizons
+128833969,Int_GuardianShieldReinforcement_Size3_Class1,internal,Guardian Shield Reinforcement,,,,3,E,horizons
+128833970,Int_GuardianShieldReinforcement_Size3_Class2,internal,Guardian Shield Reinforcement,,,,3,D,horizons
+128833971,Int_GuardianShieldReinforcement_Size4_Class1,internal,Guardian Shield Reinforcement,,,,4,E,horizons
+128833972,Int_GuardianShieldReinforcement_Size4_Class2,internal,Guardian Shield Reinforcement,,,,4,D,horizons
+128833973,Int_GuardianShieldReinforcement_Size5_Class1,internal,Guardian Shield Reinforcement,,,,5,E,horizons
+128833974,Int_GuardianShieldReinforcement_Size5_Class2,internal,Guardian Shield Reinforcement,,,,5,D,horizons
+128833975,Int_GuardianFSDBooster_Size1,internal,Guardian FSD Booster,,,,1,H,horizons
+128833976,Int_GuardianFSDBooster_Size2,internal,Guardian FSD Booster,,,,2,H,horizons
+128833977,Int_GuardianFSDBooster_Size3,internal,Guardian FSD Booster,,,,3,H,horizons
+128833978,Int_GuardianFSDBooster_Size4,internal,Guardian FSD Booster,,,,4,H,horizons
+128833979,Int_GuardianFSDBooster_Size5,internal,Guardian FSD Booster,,,,5,H,horizons
+128833980,Int_GuardianPowerDistributor_Size1,internal,Guardian Hybrid Power Distributor,,,,1,A,horizons
+128833981,Int_GuardianPowerDistributor_Size2,internal,Guardian Hybrid Power Distributor,,,,2,A,horizons
+128833982,Int_GuardianPowerDistributor_Size3,internal,Guardian Hybrid Power Distributor,,,,3,A,horizons
+128833983,Int_GuardianPowerDistributor_Size4,internal,Guardian Hybrid Power Distributor,,,,4,A,horizons
+128833984,Int_GuardianPowerDistributor_Size5,internal,Guardian Hybrid Power Distributor,,,,5,A,horizons
+128833985,Int_GuardianPowerDistributor_Size6,internal,Guardian Hybrid Power Distributor,,,,6,A,horizons
+128833986,Int_GuardianPowerDistributor_Size7,internal,Guardian Hybrid Power Distributor,,,,7,A,horizons
+128833987,Int_GuardianPowerDistributor_Size8,internal,Guardian Hybrid Power Distributor,,,,8,A,horizons
+128833988,Int_GuardianPowerplant_Size2,internal,Guardian Hybrid Power Plant,,,,2,A,horizons
+128833989,Int_GuardianPowerplant_Size3,internal,Guardian Hybrid Power Plant,,,,3,A,horizons
+128833990,Int_GuardianPowerplant_Size4,internal,Guardian Hybrid Power Plant,,,,4,A,horizons
+128833991,Int_GuardianPowerplant_Size5,internal,Guardian Hybrid Power Plant,,,,5,A,horizons
+128833992,Int_GuardianPowerplant_Size6,internal,Guardian Hybrid Power Plant,,,,6,A,horizons
+128833993,Int_GuardianPowerplant_Size7,internal,Guardian Hybrid Power Plant,,,,7,A,horizons
+128833994,Int_GuardianPowerplant_Size8,internal,Guardian Hybrid Power Plant,,,,8,A,horizons
+128833995,Hpt_CausticMissile_Fixed_Medium,hardpoint,Enzyme Missile Rack,,,2,B,horizons
+128833996,Hpt_FlechetteLauncher_Fixed_Medium,hardpoint,Remote Release Flechette Launcher,,,2,B,horizons
+128833997,Hpt_FlechetteLauncher_Turret_Medium,hardpoint,Remote Release Flechette Launcher,,,2,B,horizons
+128833998,Hpt_Guardian_PlasmaLauncher_Fixed_Medium,hardpoint,Guardian Plasma Charger,Fixed,,,2,B,horizons
+128833999,Hpt_Guardian_PlasmaLauncher_Turret_Medium,hardpoint,Guardian Plasma Charger,Turreted,,,2,E,horizons
+128834000,Hpt_Guardian_ShardCannon_Fixed_Medium,hardpoint,Guardian Shard Cannon,Fixed,,,2,A,horizons
+128834001,Hpt_Guardian_ShardCannon_Turret_medium,hardpoint,Guardian Shard Cannon,Turreted,,,2,D,horizons
+128834002,Hpt_PlasmaShockCannon_Fixed_Medium,hardpoint,Shock Cannon,,,2,D,horizons
+128834003,Hpt_PlasmaShockCannon_Gimbal_Medium,hardpoint,Shock Cannon,,,2,D,horizons
+128834004,Hpt_PlasmaShockCannon_Turret_Medium,hardpoint,Shock Cannon,,,2,E,horizons
+128834778,Hpt_Guardian_ShardCannon_Fixed_Large,hardpoint,Guardian Shard Cannon,Fixed,,,3,C,horizons
+128834779,Hpt_Guardian_ShardCannon_Turret_Large,hardpoint,Guardian Shard Cannon,Turreted,,,3,D,horizons
+128834780,Hpt_PlasmaShockCannon_Fixed_Large,hardpoint,Shock Cannon,Fixed,,,3,C,horizons
+128834781,Hpt_PlasmaShockCannon_Gimbal_Large,hardpoint,Shock Cannon,Gimballed,,,3,C,horizons
+128834782,Hpt_PlasmaShockCannon_Turret_Large,hardpoint,Shock Cannon,Turreted,,,3,D,horizons
+128834783,Hpt_Guardian_PlasmaLauncher_Fixed_Large,hardpoint,Guardian Plasma Charger,Fixed,,,3,C,horizons
+128834784,Hpt_Guardian_PlasmaLauncher_Turret_Large,hardpoint,Guardian Plasma Charger,Turreted,,,3,D,horizons
 128837858,Int_DroneControl_Recon_Size1_Class1,internal,Recon Limpet Controller,,,,1,E,
 128841592,Int_DroneControl_Recon_Size3_Class1,internal,Recon Limpet Controller,,,,3,E,
 128841593,Int_DroneControl_Recon_Size5_Class1,internal,Recon Limpet Controller,,,,5,E,


### PR DESCRIPTION
- add Meta Alloy Hull Reinforcement
- add Guardian Hull Reinforcement
- add Guardian Shield Reinforcement
- add Guardian Module Reinforcement
- add Enzyme missile launcher
- add Guardian FSD booster
- add Guardian Hybrid Power Distributor

Various fixes:
- ensure all lines have 10 fields, mostly by inserting internal/hardpoint as type
- armour for the Krait Mk II is spelled ..MKII.., not ..MKii..
- Guardian PP is called "Guardian Hybrid Power Plant" in game
- Shard Cannon -> Guardian Shard Cannon
- add missing grade for various weapons