### PR TITLE
use in-game SKU codes for limited access ships and modules

### DIFF
--- a/outfitting.csv
+++ b/outfitting.csv
@@ -820,15 +820,15 @@ id,symbol,category,name,mount,guidance,ship,class,rating,entitlement
 128672280,Asp_Scout_Armour_Grade3,standard,Military Grade Composite,,,Asp Scout,1,I,
 128672281,Asp_Scout_Armour_Mirrored,standard,Mirrored Surface Composite,,,Asp Scout,1,I,
 128672282,Asp_Scout_Armour_Reactive,standard,Reactive Surface Composite,,,Asp Scout,1,I,
-128672288,Int_BuggyBay_Size2_Class1,internal,Planetary Vehicle Hangar,,,,2,H,horizons
-128672289,Int_BuggyBay_Size2_Class2,internal,Planetary Vehicle Hangar,,,,2,G,horizons
-128672290,Int_BuggyBay_Size4_Class1,internal,Planetary Vehicle Hangar,,,,4,H,horizons
-128672291,Int_BuggyBay_Size4_Class2,internal,Planetary Vehicle Hangar,,,,4,G,horizons
-128672292,Int_BuggyBay_Size6_Class1,internal,Planetary Vehicle Hangar,,,,6,H,horizons
-128672293,Int_BuggyBay_Size6_Class2,internal,Planetary Vehicle Hangar,,,,6,G,horizons
-128672317,Int_PlanetApproachSuite,standard,Planetary Approach Suite,,,,1,I,horizons
-128681641,Int_CorrosionProofCargoRack_Size1_Class1,internal,Corrosion Resistant Cargo Rack,,,,1,E,horizons
-128681992,Int_CorrosionProofCargoRack_Size1_Class2,internal,Corrosion Resistant Cargo Rack,,,,1,F,horizons
+128672288,Int_BuggyBay_Size2_Class1,internal,Planetary Vehicle Hangar,,,,2,H,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128672289,Int_BuggyBay_Size2_Class2,internal,Planetary Vehicle Hangar,,,,2,G,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128672290,Int_BuggyBay_Size4_Class1,internal,Planetary Vehicle Hangar,,,,4,H,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128672291,Int_BuggyBay_Size4_Class2,internal,Planetary Vehicle Hangar,,,,4,G,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128672292,Int_BuggyBay_Size6_Class1,internal,Planetary Vehicle Hangar,,,,6,H,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128672293,Int_BuggyBay_Size6_Class2,internal,Planetary Vehicle Hangar,,,,6,G,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128672317,Int_PlanetApproachSuite,standard,Planetary Approach Suite,,,,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128681641,Int_CorrosionProofCargoRack_Size1_Class1,internal,Corrosion Resistant Cargo Rack,,,,1,E,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128681992,Int_CorrosionProofCargoRack_Size1_Class2,internal,Corrosion Resistant Cargo Rack,,,,1,F,ELITE_HORIZONS_V_PLANETARY_LANDINGS
 128681994,Hpt_BeamLaser_Gimbal_Huge,hardpoint,Beam Laser,Gimballed,,,4,A,
 128681995,Hpt_PulseLaser_Gimbal_Huge,hardpoint,Pulse Laser,Gimballed,,,4,A,
 128681996,Hpt_MultiCannon_Gimbal_Huge,hardpoint,Multi-Cannon,Gimballed,,,4,A,
@@ -843,9 +843,9 @@ id,symbol,category,name,mount,guidance,ship,class,rating,entitlement
 128727927,Int_PassengerCabin_Size6_Class2,internal,Business Class Passenger Cabin,,,,6,D,
 128727928,Int_PassengerCabin_Size6_Class3,internal,First Class Passenger Cabin,,,,6,C,
 128727929,Int_PassengerCabin_Size6_Class4,internal,Luxury Class Passenger Cabin,,,,6,B,
-128727930,Int_FighterBay_Size5_Class1,internal,Fighter Hangar,,,,5,D,horizons
-128727931,Int_FighterBay_Size6_Class1,internal,Fighter Hangar,,,,6,D,horizons
-128727932,Int_FighterBay_Size7_Class1,internal,Fighter Hangar,,,,7,D,horizons
+128727930,Int_FighterBay_Size5_Class1,internal,Fighter Hangar,,,,5,D,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128727931,Int_FighterBay_Size6_Class1,internal,Fighter Hangar,,,,6,D,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128727932,Int_FighterBay_Size7_Class1,internal,Fighter Hangar,,,,7,D,ELITE_HORIZONS_V_PLANETARY_LANDINGS
 128732552,Hpt_DumbfireMissileRack_Fixed_Medium_Lasso,hardpoint,Rocket Propelled FSD Disruptor,Fixed,Dumbfire,,2,B,powerplay
 128734690,Int_PassengerCabin_Size2_Class1,internal,Economy Class Passenger Cabin,,,,2,E,
 128734691,Int_PassengerCabin_Size3_Class1,internal,Economy Class Passenger Cabin,,,,3,E,
@@ -865,7 +865,7 @@ id,symbol,category,name,mount,guidance,ship,class,rating,entitlement
 128737279,Int_ModuleReinforcement_Size5_Class2,internal,Module Reinforcement Package,,,,5,D,
 128740819,Hpt_MiningLaser_Turret_Small,hardpoint,Mining Laser,Turreted,,,1,D,
 128740820,Hpt_MiningLaser_Turret_Medium,hardpoint,Mining Laser,Turreted,,,2,D,
-128771884,Hpt_AntiUnknownShutdown_Tiny,utility,Shutdown Field Neutraliser,,,,0,F,horizons
+128771884,Hpt_AntiUnknownShutdown_Tiny,utility,Shutdown Field Neutraliser,,,,0,F,ELITE_HORIZONS_V_PLANETARY_LANDINGS
 128777327,Int_DroneControl_Repair_Size1_Class1,internal,Repair Limpet Controller,,,,1,E,
 128777328,Int_DroneControl_Repair_Size1_Class2,internal,Repair Limpet Controller,,,,1,D,
 128777329,Int_DroneControl_Repair_Size1_Class3,internal,Repair Limpet Controller,,,,1,C,
@@ -886,121 +886,121 @@ id,symbol,category,name,mount,guidance,ship,class,rating,entitlement
 128777344,Int_DroneControl_Repair_Size7_Class3,internal,Repair Limpet Controller,,,,7,C,
 128777345,Int_DroneControl_Repair_Size7_Class4,internal,Repair Limpet Controller,,,,7,B,
 128777346,Int_DroneControl_Repair_Size7_Class5,internal,Repair Limpet Controller,,,,7,A,
-128785621,Type9_Military_Armour_Grade1,standard,Lightweight Alloy,,,Type-10 Defender,1,I,horizons
-128785622,Type9_Military_Armour_Grade2,standard,Reinforced Alloy,,,Type-10 Defender,1,I,horizons
-128785623,Type9_Military_Armour_Grade3,standard,Military Grade Composite,,,Type-10 Defender,1,I,horizons
-128785624,Type9_Military_Armour_Mirrored,standard,Mirrored Surface Composite,,,Type-10 Defender,1,I,horizons
-128785625,Type9_Military_Armour_Reactive,standard,Reactive Surface Composite,,,Type-10 Defender,1,I,horizons
-128785626,Hpt_FlakMortar_Fixed_Medium,hardpoint,Remote Release Flak Launcher,Fixed,,,2,B,horizons
-128788699,Hpt_ATDumbfireMissile_Fixed_Medium,hardpoint,AX Missile Rack,Fixed,Dumbfire,,2,B,horizons
-128788700,Hpt_ATDumbfireMissile_Fixed_Large,hardpoint,AX Missile Rack,Fixed,Dumbfire,,3,A,horizons
-128788701,Hpt_ATMultiCannon_Fixed_Medium,hardpoint,AX Multi-Cannon,Fixed,,,2,E,horizons
-128788702,Hpt_ATMultiCannon_Fixed_Large,hardpoint,AX Multi-Cannon,Fixed,,,3,C,horizons
-128788704,Hpt_ATDumbfireMissile_Turret_Medium,hardpoint,AX Missile Rack,Turreted,Dumbfire,,2,B,horizons
-128788705,Hpt_ATDumbfireMissile_Turret_Large,hardpoint,AX Missile Rack,Turreted,Dumbfire,,3,A,horizons
-128793058,Hpt_FlakMortar_Turret_Medium,hardpoint,Remote Release Flak Launcher,Turreted,,,2,B,horizons
-128793059,Hpt_ATMultiCannon_Turret_Medium,hardpoint,AX Multi-Cannon,Turreted,,,2,F,horizons
-128793060,Hpt_ATMultiCannon_Turret_Large,hardpoint,AX Multi-Cannon,Turreted,,,3,E,horizons
-128793115,Hpt_XenoScanner_Basic_Tiny,utility,Xeno Scanner,,,,0,E,horizons
-128793116,Int_DroneControl_UnkVesselResearch,internal,Research Limpet Controller,,,,1,E,horizons
-128793117,Int_MetaAlloyHullReinforcement_Size1_Class1,internal,Meta Alloy Hull Reinforcement,,,,1,E,horizons
-128793118,Int_MetaAlloyHullReinforcement_Size1_Class2,internal,Meta Alloy Hull Reinforcement,,,,1,D,horizons
-128793119,Int_MetaAlloyHullReinforcement_Size2_Class1,internal,Meta Alloy Hull Reinforcement,,,,2,E,horizons
-128793120,Int_MetaAlloyHullReinforcement_Size2_Class2,internal,Meta Alloy Hull Reinforcement,,,,2,D,horizons
-128793121,Int_MetaAlloyHullReinforcement_Size3_Class1,internal,Meta Alloy Hull Reinforcement,,,,3,E,horizons
-128793122,Int_MetaAlloyHullReinforcement_Size3_Class2,internal,Meta Alloy Hull Reinforcement,,,,3,D,horizons
-128793123,Int_MetaAlloyHullReinforcement_Size4_Class1,internal,Meta Alloy Hull Reinforcement,,,,4,E,horizons
-128793124,Int_MetaAlloyHullReinforcement_Size4_Class2,internal,Meta Alloy Hull Reinforcement,,,,4,D,horizons
-128793125,Int_MetaAlloyHullReinforcement_Size5_Class1,internal,Meta Alloy Hull Reinforcement,,,,5,E,horizons
-128793126,Int_MetaAlloyHullReinforcement_Size5_Class2,internal,Meta Alloy Hull Reinforcement,,,,5,D,horizons
-128793941,Int_DroneControl_Decontamination_Size1_Class1,internal,Decontamination Limpet Controller,,,,1,E,horizons
-128793942,Int_DroneControl_Decontamination_Size3_Class1,internal,Decontamination Limpet Controller,,,,3,E,horizons
-128793943,Int_DroneControl_Decontamination_Size5_Class1,internal,Decontamination Limpet Controller,,,,5,E,horizons
-128793944,Int_DroneControl_Decontamination_Size7_Class1,internal,Decontamination Limpet Controller,,,,7,E,horizons
-128816569,Krait_MkII_Armour_Grade1,standard,Lightweight Alloy,,,Krait MkII,1,I,horizons
-128816570,Krait_MkII_Armour_Grade2,standard,Reinforced Alloy,,,Krait MkII,1,I,horizons
-128816571,Krait_MkII_Armour_Grade3,standard,Military Grade Composite,,,Krait MkII,1,I,horizons
-128816572,Krait_MkII_Armour_Mirrored,standard,Mirrored Surface Composite,,,Krait MkII,1,I,horizons
-128816573,Krait_MkII_Armour_Reactive,standard,Reactive Surface Composite,,,Krait MkII,1,I,horizons
-128816576,TypeX_Armour_Grade1,standard,Lightweight Alloy,,,Alliance Chieftain,1,I,horizons
-128816577,TypeX_Armour_Grade2,standard,Reinforced Alloy,,,Alliance Chieftain,1,I,horizons
-128816578,TypeX_Armour_Grade3,standard,Military Grade Composite,,,Alliance Chieftain,1,I,horizons
-128816579,TypeX_Armour_Mirrored,standard,Mirrored Surface Composite,,,Alliance Chieftain,1,I,horizons
-128816580,TypeX_Armour_Reactive,standard,Reactive Surface Composite,,,Alliance Chieftain,1,I,horizons
-128816590,TypeX_3_Armour_Grade1,standard,Lightweight Alloy,,,Alliance Challenger,1,I,horizons
-128816591,TypeX_3_Armour_Grade2,standard,Reinforced Alloy,,,Alliance Challenger,1,I,horizons
-128816592,TypeX_3_Armour_Grade3,standard,Military Grade Composite,,,Alliance Challenger,1,I,horizons
-128816593,TypeX_3_Armour_Mirrored,standard,Mirrored Surface Composite,,,Alliance Challenger,1,I,horizons
-128816594,TypeX_3_Armour_Reactive,standard,Reactive Surface Composite,,,Alliance Challenger,1,I,horizons
-128833687,Hpt_Guardian_GaussCannon_Fixed_Medium,hardpoint,Guardian Gauss Cannon,Fixed,,,2,B,horizons
-128833944,Int_CorrosionProofCargoRack_Size4_Class1,internal,Corrosion Resistant Cargo Rack,,,,4,E,horizons
-128833945,Int_GuardianHullReinforcement_Size1_Class1,internal,Guardian Hull Reinforcement,,,,1,E,horizons
-128833946,Int_GuardianHullReinforcement_Size1_Class2,internal,Guardian Hull Reinforcement,,,,1,D,horizons
-128833947,Int_GuardianHullReinforcement_Size2_Class1,internal,Guardian Hull Reinforcement,,,,2,E,horizons
-128833948,Int_GuardianHullReinforcement_Size2_Class2,internal,Guardian Hull Reinforcement,,,,2,D,horizons
-128833949,Int_GuardianHullReinforcement_Size3_Class1,internal,Guardian Hull Reinforcement,,,,3,E,horizons
-128833950,Int_GuardianHullReinforcement_Size3_Class2,internal,Guardian Hull Reinforcement,,,,3,D,horizons
-128833951,Int_GuardianHullReinforcement_Size4_Class1,internal,Guardian Hull Reinforcement,,,,4,E,horizons
-128833952,Int_GuardianHullReinforcement_Size4_Class2,internal,Guardian Hull Reinforcement,,,,4,D,horizons
-128833953,Int_GuardianHullReinforcement_Size5_Class1,internal,Guardian Hull Reinforcement,,,,5,E,horizons
-128833954,Int_GuardianHullReinforcement_Size5_Class2,internal,Guardian Hull Reinforcement,,,,5,D,horizons
-128833955,Int_GuardianModuleReinforcement_Size1_Class1,internal,Guardian Module Reinforcement,,,,1,E,horizons
-128833956,Int_GuardianModuleReinforcement_Size1_Class2,internal,Guardian Module Reinforcement,,,,1,D,horizons
-128833957,Int_GuardianModuleReinforcement_Size2_Class1,internal,Guardian Module Reinforcement,,,,2,E,horizons
-128833958,Int_GuardianModuleReinforcement_Size2_Class2,internal,Guardian Module Reinforcement,,,,2,D,horizons
-128833959,Int_GuardianModuleReinforcement_Size3_Class1,internal,Guardian Module Reinforcement,,,,3,E,horizons
-128833960,Int_GuardianModuleReinforcement_Size3_Class2,internal,Guardian Module Reinforcement,,,,3,D,horizons
-128833961,Int_GuardianModuleReinforcement_Size4_Class1,internal,Guardian Module Reinforcement,,,,4,E,horizons
-128833962,Int_GuardianModuleReinforcement_Size4_Class2,internal,Guardian Module Reinforcement,,,,4,D,horizons
-128833963,Int_GuardianModuleReinforcement_Size5_Class1,internal,Guardian Module Reinforcement,,,,5,E,horizons
-128833964,Int_GuardianModuleReinforcement_Size5_Class2,internal,Guardian Module Reinforcement,,,,5,D,horizons
-128833965,Int_GuardianShieldReinforcement_Size1_Class1,internal,Guardian Shield Reinforcement,,,,1,E,horizons
-128833966,Int_GuardianShieldReinforcement_Size1_Class2,internal,Guardian Shield Reinforcement,,,,1,D,horizons
-128833967,Int_GuardianShieldReinforcement_Size2_Class1,internal,Guardian Shield Reinforcement,,,,2,E,horizons
-128833968,Int_GuardianShieldReinforcement_Size2_Class2,internal,Guardian Shield Reinforcement,,,,2,D,horizons
-128833969,Int_GuardianShieldReinforcement_Size3_Class1,internal,Guardian Shield Reinforcement,,,,3,E,horizons
-128833970,Int_GuardianShieldReinforcement_Size3_Class2,internal,Guardian Shield Reinforcement,,,,3,D,horizons
-128833971,Int_GuardianShieldReinforcement_Size4_Class1,internal,Guardian Shield Reinforcement,,,,4,E,horizons
-128833972,Int_GuardianShieldReinforcement_Size4_Class2,internal,Guardian Shield Reinforcement,,,,4,D,horizons
-128833973,Int_GuardianShieldReinforcement_Size5_Class1,internal,Guardian Shield Reinforcement,,,,5,E,horizons
-128833974,Int_GuardianShieldReinforcement_Size5_Class2,internal,Guardian Shield Reinforcement,,,,5,D,horizons
-128833975,Int_GuardianFSDBooster_Size1,internal,Guardian FSD Booster,,,,1,H,horizons
-128833976,Int_GuardianFSDBooster_Size2,internal,Guardian FSD Booster,,,,2,H,horizons
-128833977,Int_GuardianFSDBooster_Size3,internal,Guardian FSD Booster,,,,3,H,horizons
-128833978,Int_GuardianFSDBooster_Size4,internal,Guardian FSD Booster,,,,4,H,horizons
-128833979,Int_GuardianFSDBooster_Size5,internal,Guardian FSD Booster,,,,5,H,horizons
-128833980,Int_GuardianPowerDistributor_Size1,internal,Guardian Hybrid Power Distributor,,,,1,A,horizons
-128833981,Int_GuardianPowerDistributor_Size2,internal,Guardian Hybrid Power Distributor,,,,2,A,horizons
-128833982,Int_GuardianPowerDistributor_Size3,internal,Guardian Hybrid Power Distributor,,,,3,A,horizons
-128833983,Int_GuardianPowerDistributor_Size4,internal,Guardian Hybrid Power Distributor,,,,4,A,horizons
-128833984,Int_GuardianPowerDistributor_Size5,internal,Guardian Hybrid Power Distributor,,,,5,A,horizons
-128833985,Int_GuardianPowerDistributor_Size6,internal,Guardian Hybrid Power Distributor,,,,6,A,horizons
-128833986,Int_GuardianPowerDistributor_Size7,internal,Guardian Hybrid Power Distributor,,,,7,A,horizons
-128833987,Int_GuardianPowerDistributor_Size8,internal,Guardian Hybrid Power Distributor,,,,8,A,horizons
-128833988,Int_GuardianPowerplant_Size2,internal,Guardian Hybrid Power Plant,,,,2,A,horizons
-128833989,Int_GuardianPowerplant_Size3,internal,Guardian Hybrid Power Plant,,,,3,A,horizons
-128833990,Int_GuardianPowerplant_Size4,internal,Guardian Hybrid Power Plant,,,,4,A,horizons
-128833991,Int_GuardianPowerplant_Size5,internal,Guardian Hybrid Power Plant,,,,5,A,horizons
-128833992,Int_GuardianPowerplant_Size6,internal,Guardian Hybrid Power Plant,,,,6,A,horizons
-128833993,Int_GuardianPowerplant_Size7,internal,Guardian Hybrid Power Plant,,,,7,A,horizons
-128833994,Int_GuardianPowerplant_Size8,internal,Guardian Hybrid Power Plant,,,,8,A,horizons
-128833995,Hpt_CausticMissile_Fixed_Medium,hardpoint,Enzyme Missile Rack,Fixed,Dumbfire,,2,B,horizons
-128833996,Hpt_FlechetteLauncher_Fixed_Medium,hardpoint,Remote Release Flechette Launcher,Fixed,,,2,B,horizons
-128833997,Hpt_FlechetteLauncher_Turret_Medium,hardpoint,Remote Release Flechette Launcher,Turreted,,,2,B,horizons
-128833998,Hpt_Guardian_PlasmaLauncher_Fixed_Medium,hardpoint,Guardian Plasma Charger,Fixed,,,2,B,horizons
-128833999,Hpt_Guardian_PlasmaLauncher_Turret_Medium,hardpoint,Guardian Plasma Charger,Turreted,,,2,E,horizons
-128834000,Hpt_Guardian_ShardCannon_Fixed_Medium,hardpoint,Guardian Shard Cannon,Fixed,,,2,A,horizons
-128834001,Hpt_Guardian_ShardCannon_Turret_medium,hardpoint,Guardian Shard Cannon,Turreted,,,2,D,horizons
-128834002,Hpt_PlasmaShockCannon_Fixed_Medium,hardpoint,Shock Cannon,Fixed,,,2,D,horizons
-128834003,Hpt_PlasmaShockCannon_Gimbal_Medium,hardpoint,Shock Cannon,Gimballed,,,2,D,horizons
-128834004,Hpt_PlasmaShockCannon_Turret_Medium,hardpoint,Shock Cannon,Turreted,,,2,E,horizons
-128834778,Hpt_Guardian_ShardCannon_Fixed_Large,hardpoint,Guardian Shard Cannon,Fixed,,,3,C,horizons
-128834779,Hpt_Guardian_ShardCannon_Turret_Large,hardpoint,Guardian Shard Cannon,Turreted,,,3,D,horizons
-128834780,Hpt_PlasmaShockCannon_Fixed_Large,hardpoint,Shock Cannon,Fixed,,,3,C,horizons
-128834781,Hpt_PlasmaShockCannon_Gimbal_Large,hardpoint,Shock Cannon,Gimballed,,,3,C,horizons
-128834782,Hpt_PlasmaShockCannon_Turret_Large,hardpoint,Shock Cannon,Turreted,,,3,D,horizons
-128834783,Hpt_Guardian_PlasmaLauncher_Fixed_Large,hardpoint,Guardian Plasma Charger,Fixed,,,3,C,horizons
-128834784,Hpt_Guardian_PlasmaLauncher_Turret_Large,hardpoint,Guardian Plasma Charger,Turreted,,,3,D,horizons
+128785621,Type9_Military_Armour_Grade1,standard,Lightweight Alloy,,,Type-10 Defender,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128785622,Type9_Military_Armour_Grade2,standard,Reinforced Alloy,,,Type-10 Defender,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128785623,Type9_Military_Armour_Grade3,standard,Military Grade Composite,,,Type-10 Defender,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128785624,Type9_Military_Armour_Mirrored,standard,Mirrored Surface Composite,,,Type-10 Defender,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128785625,Type9_Military_Armour_Reactive,standard,Reactive Surface Composite,,,Type-10 Defender,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128785626,Hpt_FlakMortar_Fixed_Medium,hardpoint,Remote Release Flak Launcher,Fixed,,,2,B,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128788699,Hpt_ATDumbfireMissile_Fixed_Medium,hardpoint,AX Missile Rack,Fixed,Dumbfire,,2,B,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128788700,Hpt_ATDumbfireMissile_Fixed_Large,hardpoint,AX Missile Rack,Fixed,Dumbfire,,3,A,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128788701,Hpt_ATMultiCannon_Fixed_Medium,hardpoint,AX Multi-Cannon,Fixed,,,2,E,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128788702,Hpt_ATMultiCannon_Fixed_Large,hardpoint,AX Multi-Cannon,Fixed,,,3,C,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128788704,Hpt_ATDumbfireMissile_Turret_Medium,hardpoint,AX Missile Rack,Turreted,Dumbfire,,2,B,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128788705,Hpt_ATDumbfireMissile_Turret_Large,hardpoint,AX Missile Rack,Turreted,Dumbfire,,3,A,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128793058,Hpt_FlakMortar_Turret_Medium,hardpoint,Remote Release Flak Launcher,Turreted,,,2,B,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128793059,Hpt_ATMultiCannon_Turret_Medium,hardpoint,AX Multi-Cannon,Turreted,,,2,F,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128793060,Hpt_ATMultiCannon_Turret_Large,hardpoint,AX Multi-Cannon,Turreted,,,3,E,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128793115,Hpt_XenoScanner_Basic_Tiny,utility,Xeno Scanner,,,,0,E,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128793116,Int_DroneControl_UnkVesselResearch,internal,Research Limpet Controller,,,,1,E,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128793117,Int_MetaAlloyHullReinforcement_Size1_Class1,internal,Meta Alloy Hull Reinforcement,,,,1,E,ELITE_HORIZONS_V_METAHULL
+128793118,Int_MetaAlloyHullReinforcement_Size1_Class2,internal,Meta Alloy Hull Reinforcement,,,,1,D,ELITE_HORIZONS_V_METAHULL
+128793119,Int_MetaAlloyHullReinforcement_Size2_Class1,internal,Meta Alloy Hull Reinforcement,,,,2,E,ELITE_HORIZONS_V_METAHULL
+128793120,Int_MetaAlloyHullReinforcement_Size2_Class2,internal,Meta Alloy Hull Reinforcement,,,,2,D,ELITE_HORIZONS_V_METAHULL
+128793121,Int_MetaAlloyHullReinforcement_Size3_Class1,internal,Meta Alloy Hull Reinforcement,,,,3,E,ELITE_HORIZONS_V_METAHULL
+128793122,Int_MetaAlloyHullReinforcement_Size3_Class2,internal,Meta Alloy Hull Reinforcement,,,,3,D,ELITE_HORIZONS_V_METAHULL
+128793123,Int_MetaAlloyHullReinforcement_Size4_Class1,internal,Meta Alloy Hull Reinforcement,,,,4,E,ELITE_HORIZONS_V_METAHULL
+128793124,Int_MetaAlloyHullReinforcement_Size4_Class2,internal,Meta Alloy Hull Reinforcement,,,,4,D,ELITE_HORIZONS_V_METAHULL
+128793125,Int_MetaAlloyHullReinforcement_Size5_Class1,internal,Meta Alloy Hull Reinforcement,,,,5,E,ELITE_HORIZONS_V_METAHULL
+128793126,Int_MetaAlloyHullReinforcement_Size5_Class2,internal,Meta Alloy Hull Reinforcement,,,,5,D,ELITE_HORIZONS_V_METAHULL
+128793941,Int_DroneControl_Decontamination_Size1_Class1,internal,Decontamination Limpet Controller,,,,1,E,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128793942,Int_DroneControl_Decontamination_Size3_Class1,internal,Decontamination Limpet Controller,,,,3,E,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128793943,Int_DroneControl_Decontamination_Size5_Class1,internal,Decontamination Limpet Controller,,,,5,E,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128793944,Int_DroneControl_Decontamination_Size7_Class1,internal,Decontamination Limpet Controller,,,,7,E,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816569,Krait_MkII_Armour_Grade1,standard,Lightweight Alloy,,,Krait MkII,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816570,Krait_MkII_Armour_Grade2,standard,Reinforced Alloy,,,Krait MkII,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816571,Krait_MkII_Armour_Grade3,standard,Military Grade Composite,,,Krait MkII,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816572,Krait_MkII_Armour_Mirrored,standard,Mirrored Surface Composite,,,Krait MkII,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816573,Krait_MkII_Armour_Reactive,standard,Reactive Surface Composite,,,Krait MkII,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816576,TypeX_Armour_Grade1,standard,Lightweight Alloy,,,Alliance Chieftain,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816577,TypeX_Armour_Grade2,standard,Reinforced Alloy,,,Alliance Chieftain,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816578,TypeX_Armour_Grade3,standard,Military Grade Composite,,,Alliance Chieftain,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816579,TypeX_Armour_Mirrored,standard,Mirrored Surface Composite,,,Alliance Chieftain,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816580,TypeX_Armour_Reactive,standard,Reactive Surface Composite,,,Alliance Chieftain,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816590,TypeX_3_Armour_Grade1,standard,Lightweight Alloy,,,Alliance Challenger,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816591,TypeX_3_Armour_Grade2,standard,Reinforced Alloy,,,Alliance Challenger,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816592,TypeX_3_Armour_Grade3,standard,Military Grade Composite,,,Alliance Challenger,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816593,TypeX_3_Armour_Mirrored,standard,Mirrored Surface Composite,,,Alliance Challenger,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816594,TypeX_3_Armour_Reactive,standard,Reactive Surface Composite,,,Alliance Challenger,1,I,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128833687,Hpt_Guardian_GaussCannon_Fixed_Medium,hardpoint,Guardian Gauss Cannon,Fixed,,,2,B,ELITE_HORIZONS_V_GUARDIAN_GAUSS_FIXED_MEDIUM
+128833944,Int_CorrosionProofCargoRack_Size4_Class1,internal,Corrosion Resistant Cargo Rack,,,,4,E,ELITE_HORIZONS_V_CORROSIONCARGO_SIZE4
+128833945,Int_GuardianHullReinforcement_Size1_Class1,internal,Guardian Hull Reinforcement,,,,1,E,ELITE_HORIZONS_V_GUARDIAN_HULLREINFORCEMENT
+128833946,Int_GuardianHullReinforcement_Size1_Class2,internal,Guardian Hull Reinforcement,,,,1,D,ELITE_HORIZONS_V_GUARDIAN_HULLREINFORCEMENT
+128833947,Int_GuardianHullReinforcement_Size2_Class1,internal,Guardian Hull Reinforcement,,,,2,E,ELITE_HORIZONS_V_GUARDIAN_HULLREINFORCEMENT
+128833948,Int_GuardianHullReinforcement_Size2_Class2,internal,Guardian Hull Reinforcement,,,,2,D,ELITE_HORIZONS_V_GUARDIAN_HULLREINFORCEMENT
+128833949,Int_GuardianHullReinforcement_Size3_Class1,internal,Guardian Hull Reinforcement,,,,3,E,ELITE_HORIZONS_V_GUARDIAN_HULLREINFORCEMENT
+128833950,Int_GuardianHullReinforcement_Size3_Class2,internal,Guardian Hull Reinforcement,,,,3,D,ELITE_HORIZONS_V_GUARDIAN_HULLREINFORCEMENT
+128833951,Int_GuardianHullReinforcement_Size4_Class1,internal,Guardian Hull Reinforcement,,,,4,E,ELITE_HORIZONS_V_GUARDIAN_HULLREINFORCEMENT
+128833952,Int_GuardianHullReinforcement_Size4_Class2,internal,Guardian Hull Reinforcement,,,,4,D,ELITE_HORIZONS_V_GUARDIAN_HULLREINFORCEMENT
+128833953,Int_GuardianHullReinforcement_Size5_Class1,internal,Guardian Hull Reinforcement,,,,5,E,ELITE_HORIZONS_V_GUARDIAN_HULLREINFORCEMENT
+128833954,Int_GuardianHullReinforcement_Size5_Class2,internal,Guardian Hull Reinforcement,,,,5,D,ELITE_HORIZONS_V_GUARDIAN_HULLREINFORCEMENT
+128833955,Int_GuardianModuleReinforcement_Size1_Class1,internal,Guardian Module Reinforcement,,,,1,E,ELITE_HORIZONS_V_GUARDIAN_MODULEREINFORCEMENT
+128833956,Int_GuardianModuleReinforcement_Size1_Class2,internal,Guardian Module Reinforcement,,,,1,D,ELITE_HORIZONS_V_GUARDIAN_MODULEREINFORCEMENT
+128833957,Int_GuardianModuleReinforcement_Size2_Class1,internal,Guardian Module Reinforcement,,,,2,E,ELITE_HORIZONS_V_GUARDIAN_MODULEREINFORCEMENT
+128833958,Int_GuardianModuleReinforcement_Size2_Class2,internal,Guardian Module Reinforcement,,,,2,D,ELITE_HORIZONS_V_GUARDIAN_MODULEREINFORCEMENT
+128833959,Int_GuardianModuleReinforcement_Size3_Class1,internal,Guardian Module Reinforcement,,,,3,E,ELITE_HORIZONS_V_GUARDIAN_MODULEREINFORCEMENT
+128833960,Int_GuardianModuleReinforcement_Size3_Class2,internal,Guardian Module Reinforcement,,,,3,D,ELITE_HORIZONS_V_GUARDIAN_MODULEREINFORCEMENT
+128833961,Int_GuardianModuleReinforcement_Size4_Class1,internal,Guardian Module Reinforcement,,,,4,E,ELITE_HORIZONS_V_GUARDIAN_MODULEREINFORCEMENT
+128833962,Int_GuardianModuleReinforcement_Size4_Class2,internal,Guardian Module Reinforcement,,,,4,D,ELITE_HORIZONS_V_GUARDIAN_MODULEREINFORCEMENT
+128833963,Int_GuardianModuleReinforcement_Size5_Class1,internal,Guardian Module Reinforcement,,,,5,E,ELITE_HORIZONS_V_GUARDIAN_MODULEREINFORCEMENT
+128833964,Int_GuardianModuleReinforcement_Size5_Class2,internal,Guardian Module Reinforcement,,,,5,D,ELITE_HORIZONS_V_GUARDIAN_MODULEREINFORCEMENT
+128833965,Int_GuardianShieldReinforcement_Size1_Class1,internal,Guardian Shield Reinforcement,,,,1,E,ELITE_HORIZONS_V_GUARDIAN_SHIELDREINFORCEMENT
+128833966,Int_GuardianShieldReinforcement_Size1_Class2,internal,Guardian Shield Reinforcement,,,,1,D,ELITE_HORIZONS_V_GUARDIAN_SHIELDREINFORCEMENT
+128833967,Int_GuardianShieldReinforcement_Size2_Class1,internal,Guardian Shield Reinforcement,,,,2,E,ELITE_HORIZONS_V_GUARDIAN_SHIELDREINFORCEMENT
+128833968,Int_GuardianShieldReinforcement_Size2_Class2,internal,Guardian Shield Reinforcement,,,,2,D,ELITE_HORIZONS_V_GUARDIAN_SHIELDREINFORCEMENT
+128833969,Int_GuardianShieldReinforcement_Size3_Class1,internal,Guardian Shield Reinforcement,,,,3,E,ELITE_HORIZONS_V_GUARDIAN_SHIELDREINFORCEMENT
+128833970,Int_GuardianShieldReinforcement_Size3_Class2,internal,Guardian Shield Reinforcement,,,,3,D,ELITE_HORIZONS_V_GUARDIAN_SHIELDREINFORCEMENT
+128833971,Int_GuardianShieldReinforcement_Size4_Class1,internal,Guardian Shield Reinforcement,,,,4,E,ELITE_HORIZONS_V_GUARDIAN_SHIELDREINFORCEMENT
+128833972,Int_GuardianShieldReinforcement_Size4_Class2,internal,Guardian Shield Reinforcement,,,,4,D,ELITE_HORIZONS_V_GUARDIAN_SHIELDREINFORCEMENT
+128833973,Int_GuardianShieldReinforcement_Size5_Class1,internal,Guardian Shield Reinforcement,,,,5,E,ELITE_HORIZONS_V_GUARDIAN_SHIELDREINFORCEMENT
+128833974,Int_GuardianShieldReinforcement_Size5_Class2,internal,Guardian Shield Reinforcement,,,,5,D,ELITE_HORIZONS_V_GUARDIAN_SHIELDREINFORCEMENT
+128833975,Int_GuardianFSDBooster_Size1,internal,Guardian FSD Booster,,,,1,H,ELITE_HORIZONS_V_GUARDIAN_FSDBOOSTER
+128833976,Int_GuardianFSDBooster_Size2,internal,Guardian FSD Booster,,,,2,H,ELITE_HORIZONS_V_GUARDIAN_FSDBOOSTER
+128833977,Int_GuardianFSDBooster_Size3,internal,Guardian FSD Booster,,,,3,H,ELITE_HORIZONS_V_GUARDIAN_FSDBOOSTER
+128833978,Int_GuardianFSDBooster_Size4,internal,Guardian FSD Booster,,,,4,H,ELITE_HORIZONS_V_GUARDIAN_FSDBOOSTER
+128833979,Int_GuardianFSDBooster_Size5,internal,Guardian FSD Booster,,,,5,H,ELITE_HORIZONS_V_GUARDIAN_FSDBOOSTER
+128833980,Int_GuardianPowerDistributor_Size1,internal,Guardian Hybrid Power Distributor,,,,1,A,ELITE_HORIZONS_V_GUARDIAN_POWERDISTRIBUTOR
+128833981,Int_GuardianPowerDistributor_Size2,internal,Guardian Hybrid Power Distributor,,,,2,A,ELITE_HORIZONS_V_GUARDIAN_POWERDISTRIBUTOR
+128833982,Int_GuardianPowerDistributor_Size3,internal,Guardian Hybrid Power Distributor,,,,3,A,ELITE_HORIZONS_V_GUARDIAN_POWERDISTRIBUTOR
+128833983,Int_GuardianPowerDistributor_Size4,internal,Guardian Hybrid Power Distributor,,,,4,A,ELITE_HORIZONS_V_GUARDIAN_POWERDISTRIBUTOR
+128833984,Int_GuardianPowerDistributor_Size5,internal,Guardian Hybrid Power Distributor,,,,5,A,ELITE_HORIZONS_V_GUARDIAN_POWERDISTRIBUTOR
+128833985,Int_GuardianPowerDistributor_Size6,internal,Guardian Hybrid Power Distributor,,,,6,A,ELITE_HORIZONS_V_GUARDIAN_POWERDISTRIBUTOR
+128833986,Int_GuardianPowerDistributor_Size7,internal,Guardian Hybrid Power Distributor,,,,7,A,ELITE_HORIZONS_V_GUARDIAN_POWERDISTRIBUTOR
+128833987,Int_GuardianPowerDistributor_Size8,internal,Guardian Hybrid Power Distributor,,,,8,A,ELITE_HORIZONS_V_GUARDIAN_POWERDISTRIBUTOR
+128833988,Int_GuardianPowerplant_Size2,internal,Guardian Hybrid Power Plant,,,,2,A,ELITE_HORIZONS_V_GUARDIAN_POWERPLANT
+128833989,Int_GuardianPowerplant_Size3,internal,Guardian Hybrid Power Plant,,,,3,A,ELITE_HORIZONS_V_GUARDIAN_POWERPLANT
+128833990,Int_GuardianPowerplant_Size4,internal,Guardian Hybrid Power Plant,,,,4,A,ELITE_HORIZONS_V_GUARDIAN_POWERPLANT
+128833991,Int_GuardianPowerplant_Size5,internal,Guardian Hybrid Power Plant,,,,5,A,ELITE_HORIZONS_V_GUARDIAN_POWERPLANT
+128833992,Int_GuardianPowerplant_Size6,internal,Guardian Hybrid Power Plant,,,,6,A,ELITE_HORIZONS_V_GUARDIAN_POWERPLANT
+128833993,Int_GuardianPowerplant_Size7,internal,Guardian Hybrid Power Plant,,,,7,A,ELITE_HORIZONS_V_GUARDIAN_POWERPLANT
+128833994,Int_GuardianPowerplant_Size8,internal,Guardian Hybrid Power Plant,,,,8,A,ELITE_HORIZONS_V_GUARDIAN_POWERPLANT
+128833995,Hpt_CausticMissile_Fixed_Medium,hardpoint,Enzyme Missile Rack,Fixed,Dumbfire,,2,B,ELITE_HORIZONS_V_CAUSTIC_MEDIUM
+128833996,Hpt_FlechetteLauncher_Fixed_Medium,hardpoint,Remote Release Flechette Launcher,Fixed,,,2,B,ELITE_HORIZONS_V_FLECHETTE_FIXED_MEDIUM
+128833997,Hpt_FlechetteLauncher_Turret_Medium,hardpoint,Remote Release Flechette Launcher,Turreted,,,2,B,ELITE_HORIZONS_V_FLECHETTE_TURRET_MEDIUM
+128833998,Hpt_Guardian_PlasmaLauncher_Fixed_Medium,hardpoint,Guardian Plasma Charger,Fixed,,,2,B,ELITE_HORIZONS_V_GUARDIAN_PLASMA_FIXED_MEDIUM
+128833999,Hpt_Guardian_PlasmaLauncher_Turret_Medium,hardpoint,Guardian Plasma Charger,Turreted,,,2,E,ELITE_HORIZONS_V_GUARDIAN_PLASMA_TURRET_MEDIUM
+128834000,Hpt_Guardian_ShardCannon_Fixed_Medium,hardpoint,Guardian Shard Cannon,Fixed,,,2,A,ELITE_HORIZONS_V_GUARDIAN_SHARD_FIXED_MEDIUM
+128834001,Hpt_Guardian_ShardCannon_Turret_medium,hardpoint,Guardian Shard Cannon,Turreted,,,2,D,ELITE_HORIZONS_V_GUARDIAN_SHARD_TURRET_MEDIUM
+128834002,Hpt_PlasmaShockCannon_Fixed_Medium,hardpoint,Shock Cannon,Fixed,,,2,D,ELITE_HORIZONS_V_PLASMASHOCK_FIXED_MEDIUM
+128834003,Hpt_PlasmaShockCannon_Gimbal_Medium,hardpoint,Shock Cannon,Gimballed,,,2,D,ELITE_HORIZONS_V_PLASMASHOCK_GIMBAL_MEDIUM
+128834004,Hpt_PlasmaShockCannon_Turret_Medium,hardpoint,Shock Cannon,Turreted,,,2,E,ELITE_HORIZONS_V_PLASMASHOCK_TURRET_MEDIUM
+128834778,Hpt_Guardian_ShardCannon_Fixed_Large,hardpoint,Guardian Shard Cannon,Fixed,,,3,C,ELITE_HORIZONS_V_GUARDIAN_SHARD_FIXED_LARGE
+128834779,Hpt_Guardian_ShardCannon_Turret_Large,hardpoint,Guardian Shard Cannon,Turreted,,,3,D,ELITE_HORIZONS_V_GUARDIAN_SHARD_TURRET_LARGE
+128834780,Hpt_PlasmaShockCannon_Fixed_Large,hardpoint,Shock Cannon,Fixed,,,3,C,ELITE_HORIZONS_V_PLASMASHOCK_FIXED_LARGE
+128834781,Hpt_PlasmaShockCannon_Gimbal_Large,hardpoint,Shock Cannon,Gimballed,,,3,C,ELITE_HORIZONS_V_PLASMASHOCK_GIMBAL_LARGE
+128834782,Hpt_PlasmaShockCannon_Turret_Large,hardpoint,Shock Cannon,Turreted,,,3,D,ELITE_HORIZONS_V_PLASMASHOCK_TURRET_LARGE
+128834783,Hpt_Guardian_PlasmaLauncher_Fixed_Large,hardpoint,Guardian Plasma Charger,Fixed,,,3,C,ELITE_HORIZONS_V_GUARDIAN_PLASMA_FIXED_LARGE
+128834784,Hpt_Guardian_PlasmaLauncher_Turret_Large,hardpoint,Guardian Plasma Charger,Turreted,,,3,D,ELITE_HORIZONS_V_GUARDIAN_PLASMA_TURRET_LARGE
 128837858,Int_DroneControl_Recon_Size1_Class1,internal,Recon Limpet Controller,,,,1,E,
 128841592,Int_DroneControl_Recon_Size3_Class1,internal,Recon Limpet Controller,,,,3,E,
 128841593,Int_DroneControl_Recon_Size5_Class1,internal,Recon Limpet Controller,,,,5,E,

--- a/shipyard.csv
+++ b/shipyard.csv
@@ -1,36 +1,36 @@
-id,symbol,name
-128049249,SideWinder,Sidewinder
-128049255,Eagle,Eagle
-128049261,Hauler,Hauler
-128049267,Adder,Adder
-128049273,Viper,Viper MkIII
-128049279,CobraMkIII,Cobra MkIII
-128049285,Type6,Type-6 Transporter
-128049291,Dolphin,Dolphin
-128049297,Type7,Type-7 Transporter
-128049303,Asp,Asp Explorer
-128049309,Vulture,Vulture
-128049315,Empire_Trader,Imperial Clipper
-128049321,Federation_Dropship,Federal Dropship
-128049327,Orca,Orca
-128049333,Type9,Type-9 Heavy
-128049339,Python,Python
-128049345,BelugaLiner,Beluga Liner
-128049351,FerDeLance,Fer-de-Lance
-128049363,Anaconda,Anaconda
-128049369,Federation_Corvette,Federal Corvette
-128049375,Cutter,Imperial Cutter
-128671217,DiamondBack,Diamondback Scout
-128671223,Empire_Courier,Imperial Courier
-128671831,DiamondBackXL,Diamondback Explorer
-128672138,Empire_Eagle,Imperial Eagle
-128672145,Federation_Dropship_MkII,Federal Assault Ship
-128672152,Federation_Gunship,Federal Gunship
-128672255,Viper_MkIV,Viper MkIV
-128672262,CobraMkIV,Cobra MkIV
-128672269,Independant_Trader,Keelback
-128672276,Asp_Scout,Asp Scout
-128785619,Type9_Military,Type-10 Defender
-128816567,Krait_MkII,Krait MkII
-128816574,TypeX,Alliance Chieftain
-128816588,TypeX_3,Alliance Challenger
+id,symbol,name,entitlement
+128049249,SideWinder,Sidewinder,
+128049255,Eagle,Eagle,
+128049261,Hauler,Hauler,
+128049267,Adder,Adder,
+128049273,Viper,Viper MkIII,
+128049279,CobraMkIII,Cobra MkIII,
+128049285,Type6,Type-6 Transporter,
+128049291,Dolphin,Dolphin,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128049297,Type7,Type-7 Transporter,
+128049303,Asp,Asp Explorer,
+128049309,Vulture,Vulture,
+128049315,Empire_Trader,Imperial Clipper,
+128049321,Federation_Dropship,Federal Dropship,
+128049327,Orca,Orca,
+128049333,Type9,Type-9 Heavy,
+128049339,Python,Python,
+128049345,BelugaLiner,Beluga Liner,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128049351,FerDeLance,Fer-de-Lance,
+128049363,Anaconda,Anaconda,
+128049369,Federation_Corvette,Federal Corvette,
+128049375,Cutter,Imperial Cutter,
+128671217,DiamondBack,Diamondback Scout,
+128671223,Empire_Courier,Imperial Courier,
+128671831,DiamondBackXL,Diamondback Explorer,
+128672138,Empire_Eagle,Imperial Eagle,
+128672145,Federation_Dropship_MkII,Federal Assault Ship,
+128672152,Federation_Gunship,Federal Gunship,
+128672255,Viper_MkIV,Viper MkIV,
+128672262,CobraMkIV,Cobra MkIV,ELITE_HORIZONS_V_COBRA_MK_IV_1000
+128672269,Independant_Trader,Keelback,
+128672276,Asp_Scout,Asp Scout,
+128785619,Type9_Military,Type-10 Defender,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816567,Krait_MkII,Krait MkII,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816574,TypeX,Alliance Chieftain,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128816588,TypeX_3,Alliance Challenger,ELITE_HORIZONS_V_PLANETARY_LANDINGS

--- a/sku.csv
+++ b/sku.csv
@@ -1,0 +1,29 @@
+sku,requirement
+ELITE_HORIZONS_V_CAUSTIC_MEDIUM,unlocked via Human Tech Broker
+ELITE_HORIZONS_V_COBRA_MK_IV_1000,purchase base game and horizons before 5th Feb 2016 (PC) or 30th July 2016 (XBOX)
+ELITE_HORIZONS_V_CORROSIONCARGO_SIZE4,unlocked via Human Tech Broker
+ELITE_HORIZONS_V_FLECHETTE_FIXED_MEDIUM,unlocked via Human Tech Broker
+ELITE_HORIZONS_V_FLECHETTE_TURRET_MEDIUM,unlocked via Human Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_FSDBOOSTER,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_GAUSS_FIXED_MEDIUM,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_HULLREINFORCEMENT,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_MODULEREINFORCEMENT,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_PLASMA_FIXED_LARGE,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_PLASMA_FIXED_MEDIUM,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_PLASMA_TURRET_LARGE,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_PLASMA_TURRET_MEDIUM,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_POWERDISTRIBUTOR,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_POWERPLANT,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_SHARD_FIXED_LARGE,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_SHARD_FIXED_MEDIUM,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_SHARD_TURRET_LARGE,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_SHARD_TURRET_MEDIUM,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_GUARDIAN_SHIELDREINFORCEMENT,unlocked via Guardian Tech Broker
+ELITE_HORIZONS_V_METAHULL,unlocked via Human Tech Broker
+ELITE_HORIZONS_V_PLANETARY_LANDINGS,purchase Horizons or Horizons Season Pass or Lifetime Expansion Pass
+ELITE_HORIZONS_V_PLASMASHOCK_FIXED_LARGE,unlocked via Human Tech Broker
+ELITE_HORIZONS_V_PLASMASHOCK_FIXED_MEDIUM,unlocked via Human Tech Broker
+ELITE_HORIZONS_V_PLASMASHOCK_GIMBAL_LARGE,unlocked via Human Tech Broker
+ELITE_HORIZONS_V_PLASMASHOCK_GIMBAL_MEDIUM,unlocked via Human Tech Broker
+ELITE_HORIZONS_V_PLASMASHOCK_TURRET_LARGE,unlocked via Human Tech Broker
+ELITE_HORIZONS_V_PLASMASHOCK_TURRET_MEDIUM,unlocked via Human Tech Broker


### PR DESCRIPTION
As discussed in the EDDB channel of EDCD this afternoon, replace "horizons" in the module list by the in-game SKU symbol.  Add a column entitlement to shipyard.csv and enter the SKU codes for the ships there.  Finally, add list of all known SKU codes and how to achieve them.

Outstanding: List of SKU codes for special power play modules.