### PR TITLE
new system allegiance, commodity and modules for Operations & Nomad update

### DIFF
--- a/commodity.csv
+++ b/commodity.csv
@@ -255,3 +255,4 @@ id,symbol,category,name
 129030462,ThargoidOrganSample,Salvage,Organ Sample
 129031238,Steel,Metals,Steel
 129031327,Haematite,Minerals,Haematite
+129045961,CuratedCommodity,Industrial Materials,Curated Commodity Package

--- a/outfitting.csv
+++ b/outfitting.csv
@@ -850,9 +850,9 @@ id,symbol,category,name,mount,guidance,ship,class,rating,entitlement
 128727927,Int_PassengerCabin_Size6_Class2,internal,Business Class Passenger Cabin,,,,6,D,
 128727928,Int_PassengerCabin_Size6_Class3,internal,First Class Passenger Cabin,,,,6,C,
 128727929,Int_PassengerCabin_Size6_Class4,internal,Luxury Class Passenger Cabin,,,,6,B,
-128727930,Int_FighterBay_Size5_Class1,internal,Fighter Hangar,,,,5,D,ELITE_HORIZONS_V_PLANETARY_LANDINGS
-128727931,Int_FighterBay_Size6_Class1,internal,Fighter Hangar,,,,6,D,ELITE_HORIZONS_V_PLANETARY_LANDINGS
-128727932,Int_FighterBay_Size7_Class1,internal,Fighter Hangar,,,,7,D,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128727930,Int_FighterBay_Size5_Class1,internal,Vessel Hangar,,,,5,D,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128727931,Int_FighterBay_Size6_Class1,internal,Vessel Hangar,,,,6,D,ELITE_HORIZONS_V_PLANETARY_LANDINGS
+128727932,Int_FighterBay_Size7_Class1,internal,Vessel Hangar,,,,7,D,ELITE_HORIZONS_V_PLANETARY_LANDINGS
 128732552,Hpt_DumbfireMissileRack_Fixed_Medium_Lasso,hardpoint,Rocket Propelled FSD Disruptor,Fixed,Dumbfire,,2,B,ELITE_SPECIFIC_V_POWER_200100
 128734690,Int_PassengerCabin_Size2_Class1,internal,Economy Class Passenger Cabin,,,,2,E,
 128734691,Int_PassengerCabin_Size3_Class1,internal,Economy Class Passenger Cabin,,,,3,E,
@@ -1189,3 +1189,33 @@ id,symbol,category,name,mount,guidance,ship,class,rating,entitlement
 129043776,Int_MkII_PassengerCabin_Size5_Class2,internal,MkII Business Class Passenger Cabin,,,,5,C,
 129043777,Int_MkII_PassengerCabin_Size6_Class1,internal,MkII Economy Class Passenger Cabin,,,,5,D,
 129043778,Int_MkII_PassengerCabin_Size6_Class2,internal,MkII Business Class Passenger Cabin,,,,5,C,
+129044375,Hpt_Railgun_Fixed_Medium,mercgear,Enduring Feedback Rail Gun,,,,2,B,
+129044376,Int_PowerDistributor_Size5_Class5,mercgear,Balanced Power Distributor,,,,5,A,
+129044377,Int_ModuleReinforcement_Size5_Class2,mercgear,Heavy Duty Module Reinforcement Package,,,,5,D,
+129045428,Hpt_Mining_AbrBlstr_Fixed_Small,mercgear,Far-Reaching Abrasion Blaster,Fixed,,,1,D,
+129045429,Hpt_CausticMissile_Fixed_Medium,mercgear,High-Yield Enzyme Missile Rack,Fixed,Dumbfire,,2,B,
+129045430,Hpt_Slugshot_Gimbal_Large,mercgear,Double Screaming Fragment Cannon,Gimballed,,,3,C,
+129045431,Hpt_Slugshot_Gimbal_Small,mercgear,Double Screaming Fragment Cannon,Gimballed,,,1,E,
+129045432,Hpt_MiningLaser_Fixed_Small,mercgear,Long Range Mining Laser,Fixed,,,1,D,
+129045433,Hpt_MultiCannon_Fixed_Medium,mercgear,Rapid Phase Multi-Cannon,Fixed,,,2,E,
+129045434,Hpt_BasicMissileRack_Fixed_Medium,mercgear,Drag Seeker Missile Rack,Fixed,Seeker,,2,B,
+129045435,Hpt_BasicMissileRack_Fixed_Medium,mercgear,Lightweight Thermal Seeker Missile Rack,Fixed,Seeker,,2,B,
+129045436,Hpt_BasicMissileRack_Fixed_Medium,mercgear,Lockdown Seeker Missile Rack,Fixed,Seeker,,2,B,
+129045437,Hpt_BasicMissileRack_Fixed_Large,mercgear,Lockdown Seeker Missile Rack,Fixed,Seeker,,3,A,
+129045438,Int_PowerDistributor_Size3_Class2,mercgear,Support Focused Power Distributor,,,,3,D,
+129045439,Int_PowerDistributor_Size3_Class5,mercgear,Support Focused Power Distributor,,,,3,A,
+129045440,Int_PowerDistributor_Size4_Class2,mercgear,Support Focused Power Distributor,,,,4,D,
+129045441,Int_PowerDistributor_Size4_Class5,mercgear,Support Focused Power Distributor,,,,4,A,
+129045442,Int_PowerDistributor_Size6_Class5,mercgear,Support Focused Power Distributor,,,,6,A,
+129045443,Int_CargoRack_Size5_Class1,mercgear,Extended Cargo Rack,,,,5,E,
+129045444,Int_CargoRack_Size6_Class1,mercgear,Extended Cargo Rack,,,,6,E,
+129045445,Int_DetailedSurfaceScanner_Tiny,mercgear,Long Range Detailed Surface Scanner,,,,1,I,
+129045539,Int_FighterBayMk2_Size6_Class1,internal,Mk II Vessel Hangar,,,,6,D,ELITE_V_MKIIFIGHTERBAY
+129045540,Int_FighterBayMk2_Size5_Class1,internal,Mk II Vessel Hangar,,,,5,D,ELITE_V_MKIIFIGHTERBAY
+129045541,Int_FighterBayMk2_Size7_Class1,internal,Mk II Vessel Hangar,,,,7,D,ELITE_V_MKIIFIGHTERBAY
+129045677,Int_FighterBayMk2_Size5_Class1_Free,internal,Mk II Vessel Hangar,,,,5,D,ELITE_V_MKIIFIGHTERBAY_FREE
+129045678,Int_FighterBayMk2_Size6_Class1_Free,internal,Mk II Vessel Hangar,,,,6,D,ELITE_V_MKIIFIGHTERBAY_FREE
+129045679,Int_FighterBayMk2_Size7_Class1_Free,internal,Mk II Vessel Hangar,,,,7,D,ELITE_V_MKIIFIGHTERBAY_FREE
+129045963,Int_FighterBay_Size5_Class1_Free,internal,Vessel Hangar,,,,5,D,ELITE_V_MKIFIGHTERBAY_FREE
+129045964,Int_FighterBay_Size6_Class1_Free,internal,Vessel Hangar,,,,6,D,ELITE_V_MKIFIGHTERBAY_FREE
+129045965,Int_FighterBay_Size7_Class1_Free,internal,Vessel Hangar,,,,7,D,ELITE_V_MKIFIGHTERBAY_FREE

--- a/sku.csv
+++ b/sku.csv
@@ -53,6 +53,9 @@ ELITE_V_EXPLORER_NX,was early access purchase in the arx store (not required any
 ELITE_V_LAKON_MINER,was early access purchase in the arx store (not required anymore)
 ELITE_V_MANDALAY,was early access purchase in the arx store (not required anymore)
 ELITE_V_MEDIUM_TRANSPORT_01,was free from day one
+ELITE_V_MKIFIGHTERBAY_FREE,early access purchase in the arx store
+ELITE_V_MKIIFIGHTERBAY,early access purchase in the arx store
+ELITE_V_MKIIFIGHTERBAY_FREE,early access purchase in the arx store
 ELITE_V_PANTHER_MKII,was early access purchase in the arx store (not required anymore)
 ELITE_V_PYTHON_NX,was early access purchase in the arx store (not required anymore)
 ELITE_V_SMALL_COMBAT_01,early access purchase in the arx store

--- a/systemallegiance.csv
+++ b/systemallegiance.csv
@@ -7,3 +7,4 @@ Alliance,Alliance
 Guardian,Guardian
 Thargoid,Thargoid
 PlayerPilots,Player Pilots
+FrontlineSolutions,Frontline Solutions


### PR DESCRIPTION
* Renamed old `Fighter Hangar` to `Vessel Hangar`
* Used `mercgear` as category for modules buyable with merc coins
* Used the `nameEngineered` entry from the CAPI shipyard response instead of the generic name of the same none merc module

WARNING: The `symbol` is no longer unique, all `mercgear` modules are duplicates!